### PR TITLE
[Gui] Message Box request to keep Tasks panel...

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -729,10 +729,12 @@ void MainWindow::notifyTasksDockWidget()
         }
         QDockWidget* tasksdw = mw->findChild<QDockWidget*>(QString::fromLatin1("Tasks"));
         if (!tasksdw) {
+            Base::Console().Log("MainWindow::notifyTasksDockWidget Tasks QDockWidget not avilable\n");
             return;
         }
         QDockWidget* modeldw = mw->findChild<QDockWidget*>(QString::fromLatin1("Model"));
         if (!modeldw) {
+            Base::Console().Log("MainWindow::notifyTasksDockWidget Model QDockWidget not avilable\n");
             return;
         }
         mw->tabifyDockWidget(modeldw, tasksdw);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -709,12 +709,12 @@ void MainWindow::notifyTasksDockWidget()
 {
     QMessageBox msgBox(this);
     msgBox.setIcon(QMessageBox::Warning);
-    msgBox.setWindowTitle(tr("Tasks Dock Widget Seperation"));
-    msgBox.setText(tr("Do you want the Tasks to be seperated from the Combo View"
+    msgBox.setWindowTitle(tr("Tasks Dock Widget Separation"));
+    msgBox.setText(tr("Do you want the Tasks to be separated from the Combo View"
                       " or stay tabulated as in previous versions?"));
     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
     auto buttonY = msgBox.button(QMessageBox::Yes);
-    buttonY->setText(tr("Seperated"));
+    buttonY->setText(tr("Separated"));
     auto buttonN = msgBox.button(QMessageBox::No);
     buttonN->setText(tr("Tabulated"));
     msgBox.adjustSize(); // Silence warnings from Qt on Windows

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -728,7 +728,13 @@ void MainWindow::notifyTasksDockWidget()
             return;
         }
         QDockWidget* tasksdw = mw->findChild<QDockWidget*>(QString::fromLatin1("Tasks"));
+        if (!tasksdw) {
+            return;
+        }
         QDockWidget* modeldw = mw->findChild<QDockWidget*>(QString::fromLatin1("Model"));
+        if (!modeldw) {
+            return;
+        }
         mw->tabifyDockWidget(modeldw, tasksdw);
         modeldw->raise();
         break;

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -227,6 +227,10 @@ public Q_SLOTS:
     /**
      * Closes all document window.
      */
+    void notifyTasksDockWidget();
+    /**
+     * One off message box request to keep Tasks panel separated or tabulated.
+     */
     bool closeAllDocuments (bool close=true);
     /** Pop up a message box asking for saving document
      */


### PR DESCRIPTION
...separated or tabulated as previous versions have.

Users with older systems that have only 1024x768 or even those with 2k screens will be presented with a change making the use of Tasks panel prescriptive. This PR gives the user the choice of separated or tabulated Tasks panel as a one off question which will reappear when their config files are reset.