### PR TITLE
[Measure] Exclude Sketcher Edit Mode axes and root point..

### DIFF
--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -44,8 +44,6 @@
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Part/App/TopoShape.h>
 
-#include <Mod/Sketch/Gui/Utils.h>
-
 #include <Mod/Measure/App/Measurement.h>
 
 #include "QuickMeasure.h"
@@ -74,9 +72,6 @@ void QuickMeasure::onSelectionChanged(const Gui::SelectionChanges& msg)
     if (!doc) {
         return;
     }
-    if (isSketchInEdit(doc)) {
-        return;
-    }
 
     measurement->clear();
 
@@ -91,7 +86,10 @@ void QuickMeasure::onSelectionChanged(const Gui::SelectionChanges& msg)
         }
         else {
             for (auto& subName : subNames) {
-                measurement->addReference3D(obj, subName);
+                if (subName == "H_Axis" || subName == "V_Axis" || subName == "RootPoint") {}
+                else {
+                    measurement->addReference3D(obj, subName);
+                }
             }
         }
     }

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -161,3 +161,4 @@ void QuickMeasure::print(const QString& message)
 
 
 #include "moc_QuickMeasure.cpp"
+

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -68,8 +68,13 @@ void QuickMeasure::onSelectionChanged(const Gui::SelectionChanges& msg)
         return;
     }
     
-    Gui::Document* doc = Gui::Application::Instance->activeDocument();
-    if (!doc) { return; }
+    Gui::Document *doc = Gui::Application::Instance->activeDocument();
+    if (!doc) {
+        return;
+    }
+    if (isSketchInEdit(doc)) {
+        return;
+    }
 
     measurement->clear();
 

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -161,4 +161,3 @@ void QuickMeasure::print(const QString& message)
 
 
 #include "moc_QuickMeasure.cpp"
-

--- a/src/Mod/Measure/Gui/QuickMeasure.cpp
+++ b/src/Mod/Measure/Gui/QuickMeasure.cpp
@@ -44,6 +44,8 @@
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/Part/App/TopoShape.h>
 
+#include <Mod/Sketch/Gui/Utils.h>
+
 #include <Mod/Measure/App/Measurement.h>
 
 #include "QuickMeasure.h"


### PR DESCRIPTION
from Quick Measure selection mechanism. Ideally Quick Measure would be disabled while in Sketch Edit Mode entirely IMHO.
