### PR TITLE
[Part] Preferences max angle deflection alert

### DIFF
--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
@@ -57,11 +57,12 @@ DlgSettings3DViewPart::DlgSettings3DViewPart(QWidget* parent)
             &DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged);
     ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Part");
-    double minDeviationlowerLimit =
-        hPart->GetFloat("MinimumDeviation", ui->maxDeviation->minimum());
+    double minDeviationlowerLimit;
+    minDeviationlowerLimit = hPart->GetFloat("MinimumDeviation", ui->maxDeviation->minimum());
     ui->maxDeviation->setMinimum(minDeviationlowerLimit);
-    double minAngleDeflectionlowerLimit =
-        hPart->GetFloat("MinimumDeviation", ui->maxAngularDeflection->minimum());
+    double minAngleDeflectionlowerLimit;
+    minAngleDeflectionlowerLimit = hPart->GetFloat(
+        "MinimumDeviation", ui->maxAngularDeflection->minimum());
     ui->maxAngularDeflection->setMinimum(minAngleDeflectionlowerLimit);
 }
 
@@ -70,12 +71,13 @@ DlgSettings3DViewPart::DlgSettings3DViewPart(QWidget* parent)
  */
 DlgSettings3DViewPart::~DlgSettings3DViewPart() = default;
 
-void DlgSettings3DViewPart::onMaxDeviationValueChanged(double v)
+void DlgSettings3DViewPart::onMaxDeviationValueChanged(double vMaxDev)
 {
     if (!this->isVisible()) {
         return;
     }
-    if (v < 0.01 && !checkValue) {
+    double maxDevMinThreshold = 0.01;
+    if (vMaxDev < maxDevMinThreshold && !checkValue) {
         checkValue = true;
         QMessageBox::warning(
             this,
@@ -85,12 +87,13 @@ void DlgSettings3DViewPart::onMaxDeviationValueChanged(double v)
     }
 }
 
-void DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged(double v)
+void DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged(double vMaxAngle)
 {
     if (!this->isVisible()) {
         return;
     }
-    if (v < 2.0 && !checkValue) {
+    double vMaxAngleMinThreshold = 2.0;
+    if (vMaxAngle < vMaxAngleMinThreshold && !checkValue) {
         checkValue = true;
         QMessageBox::warning(
             this,

--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
@@ -42,15 +42,27 @@ using namespace PartGui;
  *  name 'name' and widget flags set to 'f'
  */
 DlgSettings3DViewPart::DlgSettings3DViewPart(QWidget* parent)
-  : PreferencePage(parent), ui(new Ui_DlgSettings3DViewPart), checkValue(false)
+    : PreferencePage(parent)
+    , ui(new Ui_DlgSettings3DViewPart)
+    , checkValue(false)
 {
     ui->setupUi(this);
-    connect(ui->maxDeviation, qOverload<double>(&QDoubleSpinBox::valueChanged),
-            this, &DlgSettings3DViewPart::onMaxDeviationValueChanged);
-    ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath
-        ("User parameter:BaseApp/Preferences/Mod/Part");
-    double lowerLimit = hPart->GetFloat("MinimumDeviation", ui->maxDeviation->minimum());
-    ui->maxDeviation->setMinimum(lowerLimit);
+    connect(ui->maxDeviation,
+            qOverload<double>(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgSettings3DViewPart::onMaxDeviationValueChanged);
+    connect(ui->maxAngularDeflection,
+            qOverload<double>(&QDoubleSpinBox::valueChanged),
+            this,
+            &DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged);
+    ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Part");
+    double minDeviationlowerLimit =
+        hPart->GetFloat("MinimumDeviation", ui->maxDeviation->minimum());
+    ui->maxDeviation->setMinimum(minDeviationlowerLimit);
+    double minAngleDeflectionlowerLimit =
+        hPart->GetFloat("MinimumDeviation", ui->maxAngularDeflection->minimum());
+    ui->maxAngularDeflection->setMinimum(minAngleDeflectionlowerLimit);
 }
 
 /**
@@ -60,13 +72,31 @@ DlgSettings3DViewPart::~DlgSettings3DViewPart() = default;
 
 void DlgSettings3DViewPart::onMaxDeviationValueChanged(double v)
 {
-    if (!this->isVisible())
+    if (!this->isVisible()) {
         return;
+    }
     if (v < 0.01 && !checkValue) {
         checkValue = true;
-        QMessageBox::warning(this, tr("Deviation"),
+        QMessageBox::warning(
+            this,
+            tr("Deviation"),
             tr("Setting a too small deviation causes the tessellation to take longer"
-               "and thus freezes or slows down the GUI."));
+               " and thus freezes or slows down the GUI."));
+    }
+}
+
+void DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged(double v)
+{
+    if (!this->isVisible()) {
+        return;
+    }
+    if (v < 2.0 && !checkValue) {
+        checkValue = true;
+        QMessageBox::warning(
+            this,
+            tr("Angle Deflection"),
+            tr("Setting a too small angle deviation causes the tessellation to take longer"
+               " and thus freezes or slows down the GUI."));
     }
 }
 
@@ -79,13 +109,13 @@ void DlgSettings3DViewPart::saveSettings()
     std::vector<App::Document*> docs = App::GetApplication().getDocuments();
     for (auto it : docs) {
         Gui::Document* doc = Gui::Application::Instance->getDocument(it);
-        std::vector<Gui::ViewProvider*> views = doc->getViewProvidersOfType(ViewProviderPart::getClassTypeId());
+        std::vector<Gui::ViewProvider*> views =
+            doc->getViewProvidersOfType(ViewProviderPart::getClassTypeId());
         for (auto view : views) {
             static_cast<ViewProviderPart*>(view)->reload();
         }
     }
 }
-
 void DlgSettings3DViewPart::loadSettings()
 {
     ui->maxDeviation->onRestore();

--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.cpp
@@ -57,11 +57,10 @@ DlgSettings3DViewPart::DlgSettings3DViewPart(QWidget* parent)
             &DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged);
     ParameterGrp::handle hPart = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Part");
-    double minDeviationlowerLimit;
-    minDeviationlowerLimit = hPart->GetFloat("MinimumDeviation", ui->maxDeviation->minimum());
+    const double minDeviationlowerLimit = hPart->GetFloat(
+        "MinimumDeviation", ui->maxDeviation->minimum());
     ui->maxDeviation->setMinimum(minDeviationlowerLimit);
-    double minAngleDeflectionlowerLimit;
-    minAngleDeflectionlowerLimit = hPart->GetFloat(
+    const double minAngleDeflectionlowerLimit = hPart->GetFloat(
         "MinimumDeviation", ui->maxAngularDeflection->minimum());
     ui->maxAngularDeflection->setMinimum(minAngleDeflectionlowerLimit);
 }
@@ -76,7 +75,7 @@ void DlgSettings3DViewPart::onMaxDeviationValueChanged(double vMaxDev)
     if (!this->isVisible()) {
         return;
     }
-    double maxDevMinThreshold = 0.01;
+    const double maxDevMinThreshold = 0.01;
     if (vMaxDev < maxDevMinThreshold && !checkValue) {
         checkValue = true;
         QMessageBox::warning(
@@ -92,7 +91,7 @@ void DlgSettings3DViewPart::onMaxAngularDeflectionValueChanged(double vMaxAngle)
     if (!this->isVisible()) {
         return;
     }
-    double vMaxAngleMinThreshold = 2.0;
+    const double vMaxAngleMinThreshold = 2.0;
     if (vMaxAngle < vMaxAngleMinThreshold && !checkValue) {
         checkValue = true;
         QMessageBox::warning(

--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.h
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.h
@@ -49,6 +49,7 @@ protected:
 
 private:
     void onMaxDeviationValueChanged(double);
+    void onMaxAngularDeflectionValueChanged(double);
 
 private:
     std::unique_ptr<Ui_DlgSettings3DViewPart> ui;


### PR DESCRIPTION
Following an issue where a user had set their Max Angle Deflection below 2 degrees it seemed appropriate to implement the same warning that had been previously implemented for Max Deviation.