### PR TITLE
[BIM] Fix continueMode functionality for Wall, Panel and Structure

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -424,7 +424,7 @@ class _CommandStructure:
         self.doc.recompute()
         # gui_utils.end_all_events()  # Causes a crash on Linux.
         self.tracker.finalize()
-        if FreeCADGui.draftToolBar.continueCmd.isChecked():
+        if FreeCADGui.draftToolBar.continueMode:
             self.Activated()
 
     def _createItemlist(self, baselist):

--- a/src/Mod/BIM/bimcommands/BimPanel.py
+++ b/src/Mod/BIM/bimcommands/BimPanel.py
@@ -127,7 +127,15 @@ class Arch_Panel:
             FreeCADGui.doCommand('s.Placement.Rotation = FreeCAD.Rotation(FreeCAD.Vector(1.00,0.00,0.00),90.00)')
         self.doc.commitTransaction()
         self.doc.recompute()
-        if FreeCADGui.draftToolBar.continueCmd.isChecked():
+        from PySide import QtCore
+        QtCore.QTimer.singleShot(100, self.check_continueMode)
+
+
+    def check_continueMode(self):
+
+        "checks if continueMode is true and restarts Panel"
+
+        if FreeCADGui.draftToolBar.continueMode:
             self.Activated()
 
     def taskbox(self):

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -192,7 +192,7 @@ class Arch_Wall:
             self.doc.recompute()
             # gui_utils.end_all_events()  # Causes a crash on Linux.
             self.tracker.finalize()
-            if FreeCADGui.draftToolBar.continueCmd and FreeCADGui.draftToolBar.continueCmd.isChecked():
+            if FreeCADGui.draftToolBar.continueMode:
                 self.Activated()
 
     def addDefault(self):


### PR DESCRIPTION
After finding the `continueMode` abruptly ended using `Panel` a delay was added to wait for recompute to complete.
