### PR TITLE
[BIM][Draft] QCheckBox fix regressions introduced by PR #21939

### DIFF
--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -670,7 +670,7 @@ class BIM_Classification:
                 self.form.treeClass.setCurrentItem(self.form.treeClass.itemBelow(i))
 
     def onVisible(self, index):
-        PARAMS.SetInt("BimClassificationVisibleState", index)
+        PARAMS.SetInt("BimClassificationVisibleState", getattr(index, "value", index))
         self.updateObjects()
 
     def getIcon(self,obj):

--- a/src/Mod/BIM/bimcommands/BimIfcElements.py
+++ b/src/Mod/BIM/bimcommands/BimIfcElements.py
@@ -117,6 +117,8 @@ class BIM_IfcElements:
     def update(self, index=None):
         "updates the tree widgets in all tabs"
 
+        index = getattr(index, "value", index)
+
         # store current state of tree into self.objectslist before redrawing
         for row in range(self.model.rowCount()):
             name = self.model.item(row, 0).toolTip()

--- a/src/Mod/BIM/bimcommands/BimIfcProperties.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProperties.py
@@ -205,6 +205,8 @@ class BIM_IfcProperties:
     def update(self, index=None):
         "updates the tree widgets in all tabs"
 
+        index = getattr(index, "value", index)
+
         self.model.clear()
         self.model.setHorizontalHeaderLabels(
             [
@@ -760,14 +762,14 @@ class BIM_IfcProperties:
             self.updateDicts(remove=remove)
 
     def onSelected(self, index):
-        PARAMS.SetInt("IfcPropertiesSelectedState", index)
+        PARAMS.SetInt("IfcPropertiesSelectedState", getattr(index, "value", index))
         self.objectslist, searchterms = self.rebuildObjectsList()
         self.form.searchField.clear()
         self.form.searchField.addItems(searchterms)
         self.update()
 
     def onVisible(self, index):
-        PARAMS.SetInt("IfcPropertiesVisibleState", index)
+        PARAMS.SetInt("IfcPropertiesVisibleState", getattr(index, "value", index))
         self.update()
 
 

--- a/src/Mod/BIM/bimcommands/BimIfcQuantities.py
+++ b/src/Mod/BIM/bimcommands/BimIfcQuantities.py
@@ -232,6 +232,8 @@ class BIM_IfcQuantities:
         """updates the tree widgets in all tabs. Index is not used,
         it is just there to match a qt slot requirement"""
 
+        index = getattr(index, "value", index)
+
         from PySide import QtCore, QtGui
         import Draft
 

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -430,11 +430,11 @@ class Arch_Wall:
         self.Offset = d
         params.set_param_arch("WallOffset", d)
 
-    def setUseSketch(self,i):
+    def setUseSketch(self, i):
         """Simple callback to set if walls should based on sketches."""
 
         from draftutils import params
-        params.set_param_arch("WallSketches",bool(i))
+        params.set_param_arch("WallSketches",bool(getattr(i, "value", i)))
 
     def createFromGUI(self):
         """Callback to create wall by using the _CommandWall.taskbox()"""

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -426,9 +426,9 @@ class Arch_Window:
         else:
             params.set_param_arch("WindowSill",d)
 
-    def setInclude(self,i):
+    def setInclude(self, i):
 
-        self.Include = bool(i)
+        self.Include = bool(getattr(i, "value", i))
 
     def setParams(self,param,d):
 

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -433,7 +433,7 @@ class DraftToolBar:
         QtCore.QObject.connect(self.lengthValue,QtCore.SIGNAL("valueChanged(double)"),self.changeLengthValue)
         QtCore.QObject.connect(self.angleValue,QtCore.SIGNAL("valueChanged(double)"),self.changeAngleValue)
         if hasattr(self.angleLock, "checkStateChanged"): # Qt version >= 6.7.0
-            QtCore.QObject.connect(self.angleLock,QtCore.SIGNAL("checkStateChanged(int)"),self.toggleAngle)
+            self.angleLock.checkStateChanged.connect(self.toggleAngle)
         else: # Qt version < 6.7.0
             QtCore.QObject.connect(self.angleLock,QtCore.SIGNAL("stateChanged(int)"),self.toggleAngle)
         QtCore.QObject.connect(self.radiusValue,QtCore.SIGNAL("valueChanged(double)"),self.changeRadiusValue)
@@ -461,13 +461,13 @@ class DraftToolBar:
         QtCore.QObject.connect(self.undoButton,QtCore.SIGNAL("pressed()"),self.undoSegment)
         QtCore.QObject.connect(self.selectButton,QtCore.SIGNAL("pressed()"),self.selectEdge)
         if hasattr(self.continueCmd, "checkStateChanged"): # Qt version >= 6.7.0
-            QtCore.QObject.connect(self.continueCmd,QtCore.SIGNAL("checkStateChanged(int)"),self.setContinue)
-            QtCore.QObject.connect(self.chainedModeCmd,QtCore.SIGNAL("checkStateChanged(int)"),self.setChainedMode)
-            QtCore.QObject.connect(self.isCopy,QtCore.SIGNAL("checkStateChanged(int)"),self.setCopymode)
-            QtCore.QObject.connect(self.isSubelementMode, QtCore.SIGNAL("checkStateChanged(int)"), self.setSubelementMode)
-            QtCore.QObject.connect(self.isRelative,QtCore.SIGNAL("checkStateChanged(int)"),self.setRelative)
-            QtCore.QObject.connect(self.isGlobal,QtCore.SIGNAL("checkStateChanged(int)"),self.setGlobal)
-            QtCore.QObject.connect(self.makeFace,QtCore.SIGNAL("checkStateChanged(int)"),self.setMakeFace)
+            self.continueCmd.checkStateChanged.connect(self.setContinue)
+            self.chainedModeCmd.checkStateChanged.connect(self.setChainedMode)
+            self.isCopy.checkStateChanged.connect(self.setCopymode)
+            self.isSubelementMode.checkStateChanged.connect(self.setSubelementMode)
+            self.isRelative.checkStateChanged.connect(self.setRelative)
+            self.isGlobal.checkStateChanged.connect(self.setGlobal)
+            self.makeFace.checkStateChanged.connect(self.setMakeFace)
         else: # Qt version < 6.7.0
             QtCore.QObject.connect(self.continueCmd,QtCore.SIGNAL("stateChanged(int)"),self.setContinue)
             QtCore.QObject.connect(self.chainedModeCmd,QtCore.SIGNAL("stateChanged(int)"),self.setChainedMode)
@@ -951,15 +951,15 @@ class DraftToolBar:
 #---------------------------------------------------------------------------
 
     def setContinue(self, val):
-        params.set_param(FreeCAD.activeDraftCommand.featureName, bool(val), "Mod/Draft/ContinueMode")
-        self.continueMode = bool(val)
-        self.chainedModeCmd.setEnabled(not val)
+        params.set_param(FreeCAD.activeDraftCommand.featureName, bool(getattr(val, "value", val)), "Mod/Draft/ContinueMode")
+        self.continueMode = bool(getattr(val, "value", val))
+        self.chainedModeCmd.setEnabled(not bool(getattr(val, "value", val)))
 
     def setChainedMode(self, val):
-        params.set_param("ChainedMode", bool(val))
-        self.chainedMode = bool(val)
-        self.continueCmd.setEnabled(not val)
-        if val == False:
+        params.set_param("ChainedMode", bool(getattr(val, "value", val)))
+        self.chainedMode = bool(getattr(val, "value", val))
+        self.continueCmd.setEnabled(not bool(getattr(val, "value", val)))
+        if bool(getattr(val, "value", val)) == False:
             # If user has deselected the checkbox, reactive the command
             # which will result in closing it
             FreeCAD.activeDraftCommand.Activated()
@@ -971,11 +971,10 @@ class DraftToolBar:
     #     gui_rectangles.py
     #     gui_stretch.py
     def setRelative(self, val=-1):
+        val = getattr(val, "value", val)
         if val < 0:
             if hasattr(self.isRelative, "checkStateChanged"): # Qt version >= 6.7.0
-                QtCore.QObject.disconnect(self.isRelative,
-                                      QtCore.SIGNAL("checkStateChanged(int)"),
-                                      self.setRelative)
+                self.isRelative.checkStateChanged.disconnect(self.setRelative)
             else: # Qt version < 6.7.0
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("stateChanged(int)"),
@@ -988,9 +987,7 @@ class DraftToolBar:
                 self.isRelative.setChecked(val)
                 self.relativeMode = val
             if hasattr(self.isRelative, "checkStateChanged"): # Qt version >= 6.7.0
-                QtCore.QObject.disconnect(self.isRelative,
-                                      QtCore.SIGNAL("checkStateChanged(int)"),
-                                      self.setRelative)
+                self.isRelative.checkStateChanged.disconnect(self.setRelative)
             else: # Qt version < 6.7.0
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("stateChanged(int)"),
@@ -1003,28 +1000,28 @@ class DraftToolBar:
         self.updateSnapper()
 
     def setGlobal(self, val):
-        params.set_param("GlobalMode", bool(val))
-        self.globalMode = bool(val)
+        params.set_param("GlobalMode", bool(getattr(val, "value", val)))
+        self.globalMode = bool(getattr(val, "value", val))
         self.checkLocal()
         self.displayPoint(self.new_point, self.get_last_point())
         self.updateSnapper()
 
     def setMakeFace(self, val):
-        params.set_param("MakeFaceMode", bool(val))
-        self.makeFaceMode = bool(val)
+        params.set_param("MakeFaceMode", bool(getattr(val, "value", val)))
+        self.makeFaceMode = bool(getattr(val, "value", val))
 
     def setCopymode(self, val):
         # special value for offset command
         if self.sourceCmd and self.sourceCmd.featureName == "Offset":
-            params.set_param("OffsetCopyMode", bool(val))
+            params.set_param("OffsetCopyMode", bool(getattr(val, "value", val)))
         else:
-            params.set_param("CopyMode", bool(val))
+            params.set_param("CopyMode", bool(getattr(val, "value", val)))
             # if CopyMode is changed ghosts must be updated.
             # Moveable children should not be included if CopyMode is True.
             self.sourceCmd.set_ghosts()
 
     def setSubelementMode(self, val):
-        params.set_param("SubelementMode", bool(val))
+        params.set_param("SubelementMode", bool(getattr(val, "value", val)))
         self.sourceCmd.set_ghosts()
 
     def checkx(self):

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -974,7 +974,9 @@ class DraftToolBar:
         val = getattr(val, "value", val)
         if val < 0:
             if hasattr(self.isRelative, "checkStateChanged"): # Qt version >= 6.7.0
-                self.isRelative.checkStateChanged.disconnect(self.setRelative)
+                QtCore.QObject.disconnect(self.isRelative,
+                                      QtCore.SIGNAL("checkStateChanged(Qt::CheckState)"),
+                                      self.setRelative)
             else: # Qt version < 6.7.0
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("stateChanged(int)"),
@@ -987,7 +989,9 @@ class DraftToolBar:
                 self.isRelative.setChecked(val)
                 self.relativeMode = val
             if hasattr(self.isRelative, "checkStateChanged"): # Qt version >= 6.7.0
-                self.isRelative.checkStateChanged.disconnect(self.setRelative)
+                QtCore.QObject.disconnect(self.isRelative,
+                                      QtCore.SIGNAL("checkStateChanged(Qt::CheckState)"),
+                                      self.setRelative)
             else: # Qt version < 6.7.0
                 QtCore.QObject.disconnect(self.isRelative,
                                       QtCore.SIGNAL("stateChanged(int)"),

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -247,7 +247,7 @@ class Draft_SelectPlane:
             self.offset = q.Value
 
     def on_set_center(self, val):
-        self.center = bool(val)
+        self.center = bool(getattr(val, "value", val))
         params.set_param("CenterPlaneOnView", self.center)
 
     def on_set_grid_size(self, text):

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -86,7 +86,7 @@ class ShapeStringTaskPanel:
         self.form.sbX.valueChanged.connect(self.set_point_x)
         self.form.sbY.valueChanged.connect(self.set_point_y)
         self.form.sbZ.valueChanged.connect(self.set_point_z)
-        if hasattr(self.form.cbGlobalMode.checkbox_fuse, "checkStateChanged"): # Qt version >= 6.7.0
+        if hasattr(self.form.cbGlobalMode, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.cbGlobalMode.checkStateChanged.connect(self.set_global_mode)
         else: # Qt version < 6.7.0
             self.form.cbGlobalMode.stateChanged.connect(self.set_global_mode)

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -160,7 +160,7 @@ class ShapeStringTaskPanel:
         params.set_param("ShapeStringFontFile", self.font_file)
 
     def set_global_mode(self, val):
-        self.global_mode = bool(val)
+        self.global_mode = bool(getattr(val, "value", val))
         params.set_param("GlobalMode", self.global_mode)
         self.change_coord_labels()
         self.display_point(self.point)


### PR DESCRIPTION
Existing code expects Integer `0` or `2` as output by `stateChanged` but `checkStateChanged` outputs by default `CheckState.Unchecked`/`CheckState.Checked` so this PR ensures both are handled correctly.