### PR TITLE
[Measure] Fix compiling errors

### DIFF
--- a/src/Mod/Measure/App/MeasureArea.h
+++ b/src/Mod/Measure/App/MeasureArea.h
@@ -74,7 +74,7 @@ public:
     }
 
     // Return a placement for the viewprovider, just use the first element for now
-    Base::Placement getPlacement() const override;
+    Base::Placement getPlacement() const;
 
     // Return the object we are measuring
     std::vector<App::DocumentObject*> getSubject() const override;

--- a/src/Mod/Measure/App/MeasureLength.h
+++ b/src/Mod/Measure/App/MeasureLength.h
@@ -71,7 +71,7 @@ public:
     }
 
     // Return a placement for the viewprovider, just use the first element for now
-    Base::Placement getPlacement() const override;
+    Base::Placement getPlacement() const;
 
     // Return the object we are measuring
     std::vector<App::DocumentObject*> getSubject() const override;

--- a/src/Mod/Measure/App/MeasurePosition.h
+++ b/src/Mod/Measure/App/MeasurePosition.h
@@ -74,7 +74,7 @@ public:
     }
     QString getResultString() override;
 
-    Base::Placement getPlacement() const override;
+    Base::Placement getPlacement() const;
 
     // Return the object we are measuring
     std::vector<App::DocumentObject*> getSubject() const override;

--- a/src/Mod/Measure/App/MeasureRadius.h
+++ b/src/Mod/Measure/App/MeasureRadius.h
@@ -74,7 +74,7 @@ public:
     }
 
     // Return a placement for the viewprovider, just use the first element for now
-    Base::Placement getPlacement() const override;
+    Base::Placement getPlacement() const;
     // Return a point on curve for the viewprovider
     Base::Vector3d getPointOnCurve() const;
 


### PR DESCRIPTION
Fix errors when compiling:

```
In file included from /home/username/freecad-1_1-source/src/Mod/Measure/App/AppMeasure.cpp:43:
/home/username/freecad-1_1-source/src/Mod/Measure/App/MeasurePosition.h:77:21: error: ‘Base::Placement Measure::MeasurePosition::getPlacement() const’ marked ‘override’, but does not override
   77 |     Base::Placement getPlacement() const override;
      |                     ^~~~~~~~~~~~
In file included from /home/username/freecad-1_1-source/src/Mod/Measure/App/AppMeasure.cpp:44:
/home/username/freecad-1_1-source/src/Mod/Measure/App/MeasureLength.h:74:21: error: ‘Base::Placement Measure::MeasureLength::getPlacement() const’ marked ‘override’, but does not override
   74 |     Base::Placement getPlacement() const override;
      |                     ^~~~~~~~~~~~
In file included from /home/username/freecad-1_1-source/src/Mod/Measure/App/AppMeasure.cpp:45:
/home/username/freecad-1_1-source/src/Mod/Measure/App/MeasureArea.h:77:21: error: ‘Base::Placement Measure::MeasureArea::getPlacement() const’ marked ‘override’, but does not override
   77 |     Base::Placement getPlacement() const override;
      |                     ^~~~~~~~~~~~
In file included from /home/username/freecad-1_1-source/src/Mod/Measure/App/AppMeasure.cpp:46:
/home/username/freecad-1_1-source/src/Mod/Measure/App/MeasureRadius.h:77:21: error: ‘Base::Placement Measure::MeasureRadius::getPlacement() const’ marked ‘override’, but does not override
   77 |     Base::Placement getPlacement() const override;
      |                     ^~~~~~~~~~~~

```